### PR TITLE
Date validator

### DIFF
--- a/src/v.validators.js
+++ b/src/v.validators.js
@@ -1,6 +1,29 @@
 function getValidators() {
     "use strict";
 
+    var dateFormatsAliases = {
+        'yyyy-mm-dd': 'iso',
+        'iso-8601': 'iso',
+        'mm/dd/yyyy': 'ansi' //ANSI INCITS 30-1997
+    };
+
+    var dateFormats = {
+        // yyyy-m(m)-d(d)
+        iso: function(val) {
+            return /^\d\d\d\d\-\d?\d\-\d?\d$/.test(val);
+        },
+
+        // m(m)/d(d)/yyyy
+        ansi: function(val) {
+            return /^\d?\d\/\d?\d\/\d\d\d\d$/.test(val);
+        },
+
+        // d(d).m(m).yyyy
+        'dd.mm.yyyy': function(val) {
+            return /^\d?\d\.\d?\d\.\d\d\d\d$/.test(val);
+        }
+    };
+
     return {
         email : function(val, message){
             var reg = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
@@ -28,6 +51,121 @@ function getValidators() {
         },
         word: function(val, message) {
             return /^\w+$/.test(val) || message || 'word string is invalid';
+        },
+        date: function(val, format, message) {
+
+
+            var isValid = false;
+
+            if (!message && !isDateFormat(dateFormatsAliases, dateFormats, format)) {
+                message = format;
+
+                // "dispatch" runs next step only if result not existy so need to make null instead of false
+                isValid = dispatch(
+                    nullable(runDateFormatVal(dateFormatsAliases, dateFormats, 'dd.mm.yyyy')),
+                    nullable(runDateFormatVal(dateFormatsAliases, dateFormats, 'ansi')),
+                    nullable(runDateFormatVal(dateFormatsAliases, dateFormats, 'iso'))
+                )(val);
+            } else {
+                format = aliasDateFormat(dateFormatsAliases, format);
+                isValid = runDateFormat(dateFormatsAliases, dateFormats, format, val);
+            }
+
+            return isValid || message || 'date string is invalid';
         }
     };
+}
+
+// Date formats functions
+
+function isDateFormat(aliases, formats, format) {
+    format = aliasDateFormat(aliases, format);
+
+    return existy(formats[format]);
+}
+
+function aliasDateFormat(aliases, format) {
+    return existy(aliases[format]) ? aliases[format] : format;
+}
+
+function runDateFormat(aliases, formats, format, val) {
+    format = format.toLowerCase();
+    format = aliasDateFormat(aliases, format);
+    return formats[format](val);
+}
+
+function runDateFormatVal(aliases, formats, format) {
+    return function(val) {
+        return runDateFormat(aliases, formats, format, val);
+    }
+}
+
+// Helpers
+
+function nullable(fn) {
+    return function() {
+        var r = fn.apply(fn, arguments);
+        return r ? r : null;
+    };
+}
+
+
+// Functions dispatch and dependencies
+
+function dispatch() {
+    var funs = toArray(arguments),
+        size = funs.length;
+
+    return function(target) {
+        var ret = undefined,
+            args = getRest(toArray(arguments));
+
+        for (var funIndex = 0; funIndex < size; funIndex++ ) {
+            var fun = funs[funIndex];
+
+            ret = fun.apply(fun, construct(target, args));
+
+            if (existy(ret)) return ret;
+        }
+
+        return ret;
+    };
+}
+
+
+function toArray(arr){
+    return (
+        (Array.isArray(arr) && arr)
+        || (!Array.isArray(arr) && arr.length && [].slice.call(arr))
+        || (typeof arr === 'string' && arr.split(''))
+        || (typeof arr === 'object' && [])
+    )
+}
+
+function getRest(arrOrString){
+    return toArray(arrOrString).slice(1);
+}
+
+function cat() {
+    var args = toArray(arguments),
+        head = getFirst(args);
+
+    if (existy(head)){
+        return head.concat.apply(head, getRest(args));
+    }
+
+    return [];
+}
+
+function construct(head, tail) {
+    return cat([head], Array.isArray(tail) ? tail : [tail]);
+}
+
+
+function getFirst(arrOrString) {
+    return arrOrString[0];
+}
+
+function existy(x) {
+    return x != null
 }

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -1,0 +1,89 @@
+
+describe("ISO Date spec", function() {
+    var checkDateIso = dateValidate('iso');
+
+    it("Should correctly check ISO format", function() {
+        expectTrue(checkDateIso('2000-01-01'));
+        expectTrue(checkDateIso('2000-1-1'));
+        expectTrue(checkDateIso('2000-01-1'));
+
+
+
+        expectFalse(checkDateIso('20-01-01'));
+        expectFalse(checkDateIso(''));
+        expectFalse(checkDateIso('2000.10.10'));
+    });
+});
+
+describe("ANSI INCITS 30-1997 date spec", function() {
+    var checkDateAnsi = dateValidate('ansi');
+
+    it("Should correctly check United States format", function() {
+        expectTrue(checkDateAnsi('01/01/2000'));
+        expectTrue(checkDateAnsi('01/20/2000'));
+
+        expectFalse(checkDateAnsi(''));
+        expectFalse(checkDateAnsi('01/01/20'));
+        expectFalse(checkDateAnsi('2000.10.10'));
+    });
+});
+
+describe("dd.mm.yyyy date spec", function() {
+    var checkDate = dateValidate('dd.mm.yyyy');
+
+    it("Should correctly check dd.mm.yyyy format", function() {
+        expectTrue(checkDate('01.01.2000'));
+        expectTrue(checkDate('01.20.2000'));
+
+        expectFalse(checkDate('01.01.20'));
+        expectFalse(checkDate(''));
+        expectFalse(checkDate('2000-10-10'));
+    });
+});
+
+
+describe("Universal date spec", function() {
+
+    var checkDate = dateValidateUniversal();
+
+    it("Should correctly check date in all formats", function() {
+        expectTrue(checkDate('01.12.2000'));
+        expectTrue(checkDate('20/10/2000'));
+        expectTrue(checkDate('2000-10-10'));
+        expectFalse(checkDate('efef'));
+        expectFalse(checkDate('20000-10-10'));
+        expectFalse(checkDate('2000-100-10'));
+        expectFalse(checkDate('2000-10-100'));
+
+        // @TODO: check logic correctness of dates
+        // expectFalse(checkDate('2000-01-32'));
+        // expectFalse(checkDate('2000-13-15'));
+        // expectFalse(checkDate('2000-02-30')); // 30 Feb
+    });
+});
+
+// Functions
+
+function dateValidate(format) {
+    var V = initValidators(getBaseValidatorFunctions(), getValidators());
+    return function(value) {
+        return V.date(format)(value);
+    };
+}
+
+
+function dateValidateUniversal() {
+    var V = initValidators(getBaseValidatorFunctions(), getValidators());
+    return function(value) {
+        return V.date()(value);
+    };
+}
+
+
+function expectTrue(value) {
+    return expect(value).toEqual(true);
+}
+
+function expectFalse(value) {
+    return expect(value).not.toEqual(true);
+}


### PR DESCRIPTION
V.date()(val) - validates with any format
V.date(format)(val) - validates with specified format. Example: V.date('dd.mm.yyyy')(val)

You can add aliases to format names for better functions usability.
Example: V.date('dd.mm.yyyy')(val), V.date('iso')(val) == V.date('yyyy-mm-dd')(val)

I used "dispatch" from FP-workshop and its dependencies.
